### PR TITLE
Docker support for unit tests

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,14 @@
+name: Test in Docker
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🚚 Checkout Repo
+        uses: actions/checkout@v2
+      - name: 🐳 Build Container
+        run: docker-compose build
+      - name: 🧪 Test in Docker
+        run: docker-compose up

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 composer.lock
 coverage/
 .phpunit.result.cache
+.cache/

--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ $architecture = (new Architecture)
     ->addComposerBasedComponent('packages/subpackage/composer.json');
 ```
 
+## Development Environment
+
+Unit tests can be run using docker:
+
+```bash
+docker-compose build
+docker-compose up
+```
+
 ## Examples
 
 - [PHPArch tests its own architecture](./tests/ArchitectureTest.php)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,6 @@ services:
   php:
     build: ./
     working_dir: /phparch
-    command: bash -c "composer install && phpunit -vvv"
+    command: bash -c "composer install && ./vendor/bin/phpunit -vvv"
     volumes:
       - ./:/phparch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services: 
+  php:
+    build: ./
+    working_dir: /phparch
+    command: bash -c "composer install && phpunit -vvv"
+    volumes:
+      - ./:/phparch

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-cli
+FROM php:7.4-cli
 
 RUN apt-get update 
 RUN apt-get install -y curl zip

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,10 @@
+FROM php:7-cli
+
+RUN apt-get update 
+RUN apt-get install -y curl zip
+
+RUN curl -sS https://getcomposer.org/installer | php
+RUN mv composer.phar /usr/local/bin/composer
+RUN composer global require "phpunit/phpunit"
+ENV PATH /root/.composer/vendor/bin:$PATH
+RUN ln -s /root/.composer/vendor/bin/phpunit /usr/bin/phpunit

--- a/dockerfile
+++ b/dockerfile
@@ -1,10 +1,9 @@
 FROM php:7.4-cli
 
 RUN apt-get update 
-RUN apt-get install -y curl zip
+RUN apt-get install -y git
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-RUN curl -sS https://getcomposer.org/installer | php
-RUN mv composer.phar /usr/local/bin/composer
 RUN composer global require "phpunit/phpunit"
 ENV PATH /root/.composer/vendor/bin:$PATH
 RUN ln -s /root/.composer/vendor/bin/phpunit /usr/bin/phpunit

--- a/dockerfile
+++ b/dockerfile
@@ -1,9 +1,2 @@
 FROM php:7.4-cli
-
-RUN apt-get update 
-RUN apt-get install -y git
 COPY --from=composer /usr/bin/composer /usr/bin/composer
-
-RUN composer global require "phpunit/phpunit"
-ENV PATH /root/.composer/vendor/bin:$PATH
-RUN ln -s /root/.composer/vendor/bin/phpunit /usr/bin/phpunit

--- a/dockerfile
+++ b/dockerfile
@@ -1,2 +1,4 @@
 FROM php:7.4-cli
+RUN apt-get update 
+RUN apt-get install -y git zip
 COPY --from=composer /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
Added docker files to the home directory and added notes at the bottom of the main readme to make it easy for new developers to run/test phparch in a Linux container

Note that 1 test currently fails: https://github.com/j6s/phparch/issues/22