### PR TITLE
TASK | Optimizing multiple composer file loading by caching ability

### DIFF
--- a/src/Component/Architecture.php
+++ b/src/Component/Architecture.php
@@ -3,8 +3,8 @@
 namespace J6s\PhpArch\Component;
 
 use J6s\PhpArch\Exception\ComponentNotDefinedException;
-use J6s\PhpArch\Utility\CachedComposerFileParser;
-use J6s\PhpArch\Utility\ComposerFileParser;
+use J6s\PhpArch\Utility\BaseComposerFileParserFactory;
+use J6s\PhpArch\Utility\ComposerFileParserFactory;
 use J6s\PhpArch\Validation\ValidationCollection;
 use J6s\PhpArch\Utility\ArrayUtility;
 
@@ -18,10 +18,22 @@ class Architecture extends ValidationCollection
 
     private ?Component $lastComponent = null;
 
+    private ComposerFileParserFactory $composerFileParserFactory;
+
+    public function __construct(array $validators = [])
+    {
+        parent::__construct($validators);
+
+        $this->composerFileParserFactory = new BaseComposerFileParserFactory();
+    }
+
     /**
-     * @var ComposerFileParser[]
+     * @param ComposerFileParserFactory $composerFileParserFactory
      */
-    private static array $composerFileParsers = [];
+    public function setComposerFileParserFactory(ComposerFileParserFactory $composerFileParserFactory): void
+    {
+        $this->composerFileParserFactory = $composerFileParserFactory;
+    }
 
     /**
      * Adds or selects a component that is identified by the given name.
@@ -237,7 +249,7 @@ class Architecture extends ValidationCollection
         bool $includeDev = false
     ): self {
         $this->getCurrent()->mustOnlyDependOnComposerDependencies(
-            self::$composerFileParsers[$composerFile] ?? self::$composerFileParsers[$composerFile] = new CachedComposerFileParser($composerFile, $lockFile),
+            $this->composerFileParserFactory->create($composerFile, $lockFile),
             $includeDev
         );
         return $this;
@@ -262,7 +274,7 @@ class Architecture extends ValidationCollection
         string $componentName = null,
         bool $includeDev = false
     ): self {
-        $parser = new ComposerFileParser($composerFile, $lockFile);
+        $parser = $this->composerFileParserFactory->create($composerFile, $lockFile);
         $this->component($componentName ?? $parser->getName());
 
         foreach ($parser->getNamespaces() as $namespace) {

--- a/src/Component/Architecture.php
+++ b/src/Component/Architecture.php
@@ -3,6 +3,7 @@
 namespace J6s\PhpArch\Component;
 
 use J6s\PhpArch\Exception\ComponentNotDefinedException;
+use J6s\PhpArch\Utility\CachedComposerFileParser;
 use J6s\PhpArch\Utility\ComposerFileParser;
 use J6s\PhpArch\Validation\ValidationCollection;
 use J6s\PhpArch\Utility\ArrayUtility;
@@ -16,6 +17,11 @@ class Architecture extends ValidationCollection
     private ?Component $currentComponent = null;
 
     private ?Component $lastComponent = null;
+
+    /**
+     * @var ComposerFileParser[]
+     */
+    private static array $composerFileParsers = [];
 
     /**
      * Adds or selects a component that is identified by the given name.
@@ -231,7 +237,7 @@ class Architecture extends ValidationCollection
         bool $includeDev = false
     ): self {
         $this->getCurrent()->mustOnlyDependOnComposerDependencies(
-            new ComposerFileParser($composerFile, $lockFile),
+            self::$composerFileParsers[$composerFile] ?? self::$composerFileParsers[$composerFile] = new CachedComposerFileParser($composerFile, $lockFile),
             $includeDev
         );
         return $this;

--- a/src/Utility/BaseComposerFileParserFactory.php
+++ b/src/Utility/BaseComposerFileParserFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace J6s\PhpArch\Utility;
+
+final class BaseComposerFileParserFactory implements ComposerFileParserFactory
+{
+    public function create(string $composerFile, string $lockFile = null): ComposerFileParser
+    {
+        return new ComposerFileParser($composerFile, $lockFile);
+    }
+}

--- a/src/Utility/CachedComposerFileParser.php
+++ b/src/Utility/CachedComposerFileParser.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace J6s\PhpArch\Utility;
+
+class CachedComposerFileParser extends ComposerFileParser
+{
+    private array $deepRequirementNamespaces = [];
+    private array $namespaces = [];
+    private array $directDependencies = [];
+
+    public function getNamespaces(bool $includeDev = false): array
+    {
+        if (true === \array_key_exists((int) $includeDev, $this->namespaces)) {
+            return $this->namespaces[(int)$includeDev];
+        }
+
+        $this->namespaces[(int)$includeDev] = parent::getNamespaces($includeDev);
+
+        return $this->namespaces[(int)$includeDev];
+    }
+
+    public function getDirectDependencies(bool $includeDev): array
+    {
+        if (true === \array_key_exists((int) $includeDev, $this->directDependencies)) {
+            return $this->directDependencies[(int)$includeDev];
+        }
+
+        $this->directDependencies[(int)$includeDev] = parent::getDirectDependencies($includeDev);
+
+        return $this->directDependencies[(int)$includeDev];
+    }
+
+
+    public function getDeepRequirementNamespaces(bool $includeDev): array
+    {
+        if (true === \array_key_exists((int) $includeDev, $this->deepRequirementNamespaces)) {
+            return $this->deepRequirementNamespaces[(int)$includeDev];
+        }
+
+        $this->deepRequirementNamespaces[(int)$includeDev] = parent::getDeepRequirementNamespaces($includeDev);
+
+        return $this->deepRequirementNamespaces[(int)$includeDev];
+    }
+}

--- a/src/Utility/CachedComposerFileParserFactory.php
+++ b/src/Utility/CachedComposerFileParserFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace J6s\PhpArch\Utility;
+
+class CachedComposerFileParserFactory implements ComposerFileParserFactory
+{
+    private array $composerFileParsersCache = [];
+
+    public function create(string $composerFile, string $lockFile = null): ComposerFileParser
+    {
+        if (false === isset($this->composerFileParsersCache[$composerFile][$lockFile])) {
+            $this->composerFileParsersCache[$composerFile][$lockFile] = new CachedComposerFileParser(
+                $composerFile,
+                $lockFile
+            );
+        }
+
+        return $this->composerFileParsersCache[$composerFile][$lockFile];
+    }
+}

--- a/src/Utility/ComposerFileParserFactory.php
+++ b/src/Utility/ComposerFileParserFactory.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace J6s\PhpArch\Utility;
+
+interface ComposerFileParserFactory
+{
+    public function create(string $composerFile, string $lockFile = null): ComposerFileParser;
+}


### PR DESCRIPTION
I've added caching to ComposerFileParser in Architecture because in the case of a scenario when we have a modular monolith with separated modules that we want to separate and force them to use only main Composer dependencies, for every module same composer file was loaded again and again. 

Thanks to that changes it will be loaded once and then use cache in a single run. 